### PR TITLE
Port @mraleph optimizations 

### DIFF
--- a/lib/quick-sort.js
+++ b/lib/quick-sort.js
@@ -109,7 +109,7 @@ function doQuickSort(ary, comparator, p, r) {
 function cloneSort(comparator) {
   let template = SortTemplate.toString();
   let templateFn = new Function(`return ${template}`)();
-  return templateFn(comparator);  // Invoke template to get doQuickSort
+  return templateFn(comparator);
 }
 
 /**
@@ -121,7 +121,7 @@ function cloneSort(comparator) {
  *        Function to use to compare two items.
  */
 
-let sortCache = new WeakMap();  // Cache for specialized sorts.
+let sortCache = new WeakMap();
 exports.quickSort = function (ary, comparator, start = 0) {
   let doQuickSort = sortCache.get(comparator);
   if (doQuickSort === void 0) {

--- a/lib/quick-sort.js
+++ b/lib/quick-sort.js
@@ -122,11 +122,11 @@ function cloneSort(comparator) {
  */
 
 let sortCache = new WeakMap();  // Cache for specialized sorts.
-exports.quickSort = function (ary, comparator) {
+exports.quickSort = function (ary, comparator, start = 0) {
   let doQuickSort = sortCache.get(comparator);
   if (doQuickSort === void 0) {
     doQuickSort = cloneSort(comparator);
     sortCache.set(comparator, doQuickSort);
   }
-  doQuickSort(ary, comparator, 0, ary.length - 1);
+  doQuickSort(ary, comparator, start, ary.length - 1);
 };

--- a/lib/quick-sort.js
+++ b/lib/quick-sort.js
@@ -15,6 +15,8 @@
 // sorting in C++. By using our own JS-implemented Quick Sort (below), we get
 // a ~3500ms mean speed-up in `bench/bench.html`.
 
+function SortTemplate(comparator) {
+
 /**
  * Swap the elements indexed by `x` and `y` in the array `ary`.
  *
@@ -101,6 +103,15 @@ function doQuickSort(ary, comparator, p, r) {
   }
 }
 
+  return doQuickSort;
+}
+
+function cloneSort(comparator) {
+  let template = SortTemplate.toString();
+  let templateFn = new Function(`return ${template}`)();
+  return templateFn(comparator);  // Invoke template to get doQuickSort
+}
+
 /**
  * Sort the given array in-place with the given comparator function.
  *
@@ -109,6 +120,13 @@ function doQuickSort(ary, comparator, p, r) {
  * @param {function} comparator
  *        Function to use to compare two items.
  */
+
+let sortCache = new WeakMap();  // Cache for specialized sorts.
 exports.quickSort = function (ary, comparator) {
+  let doQuickSort = sortCache.get(comparator);
+  if (doQuickSort === void 0) {
+    doQuickSort = cloneSort(comparator);
+    sortCache.set(comparator, doQuickSort);
+  }
   doQuickSort(ary, comparator, 0, ary.length - 1);
 };

--- a/lib/quick-sort.js
+++ b/lib/quick-sort.js
@@ -85,7 +85,7 @@ function doQuickSort(ary, comparator, p, r) {
     //
     //   * Every element in `ary[i+1 .. j-1]` is greater than the pivot.
     for (var j = p; j < r; j++) {
-      if (comparator(ary[j], pivot) <= 0) {
+      if (comparator(ary[j], pivot, false) <= 0) {
         i += 1;
         swap(ary, i, j);
       }

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -493,11 +493,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
         mapping = new Mapping();
         mapping.generatedLine = generatedLine;
 
-        // Because each offset is encoded relative to the previous one,
-        // many segments often have the same encoding. We can exploit this
-        // fact by caching the parsed variable length fields of each segment,
-        // allowing us to avoid a second parse if we encounter the same
-        // segment again.
         for (end = index; end < length; end++) {
           if (this._charIsMappingSeparator(aStr, end)) {
             break;
@@ -505,27 +500,20 @@ BasicSourceMapConsumer.prototype._parseMappings =
         }
         str = aStr.slice(index, end);
 
-        segment = cachedSegments[str];
-        if (segment) {
-          index += str.length;
-        } else {
-          segment = [];
-          while (index < end) {
-            base64VLQ.decode(aStr, index, temp);
-            value = temp.value;
-            index = temp.rest;
-            segment.push(value);
-          }
+        segment = [];
+        while (index < end) {
+          base64VLQ.decode(aStr, index, temp);
+          value = temp.value;
+          index = temp.rest;
+          segment.push(value);
+        }
 
-          if (segment.length === 2) {
-            throw new Error('Found a source, but no line and column');
-          }
+        if (segment.length === 2) {
+          throw new Error('Found a source, but no line and column');
+        }
 
-          if (segment.length === 3) {
-            throw new Error('Found a source and line, but no column');
-          }
-
-          cachedSegments[str] = segment;
+        if (segment.length === 3) {
+          throw new Error('Found a source and line, but no column');
         }
 
         // Generated column.

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -578,8 +578,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
 
         generatedMappings.push(mapping);
         if (typeof mapping.originalLine === 'number') {
-          // This code used to just do: originalMappings.push(mapping).
-          // Now it sorts original mappings already by source during parsing.
           let currentSource = mapping.source;
           while (originalMappings.length <= currentSource) {
             originalMappings.push(null);
@@ -595,8 +593,6 @@ BasicSourceMapConsumer.prototype._parseMappings =
     sortGenerated(generatedMappings, subarrayStart);
     this.__generatedMappings = generatedMappings;
 
-    // The code used to sort the whole array:
-    // quickSort(originalMappings, util.compareByOriginalPositions);
     for (var i = 0; i < originalMappings.length; i++) {
       if (originalMappings[i] != null) {
         quickSort(originalMappings[i], util.compareByOriginalPositionsNoSource);

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -556,7 +556,16 @@ BasicSourceMapConsumer.prototype._parseMappings =
 
         generatedMappings.push(mapping);
         if (typeof mapping.originalLine === 'number') {
-          originalMappings.push(mapping);
+          // This code used to just do: originalMappings.push(mapping).
+          // Now it sorts original mappings already by source during parsing.
+          let currentSource = mapping.source;
+          while (originalMappings.length <= currentSource) {
+            originalMappings.push(null);
+          }
+          if (originalMappings[currentSource] === null) {
+            originalMappings[currentSource] = [];
+          }
+          originalMappings[currentSource].push(mapping);
         }
       }
     }
@@ -564,8 +573,14 @@ BasicSourceMapConsumer.prototype._parseMappings =
     quickSort(generatedMappings, util.compareByGeneratedPositionsDeflated);
     this.__generatedMappings = generatedMappings;
 
-    quickSort(originalMappings, util.compareByOriginalPositions);
-    this.__originalMappings = originalMappings;
+    // The code used to sort the whole array:
+    // quickSort(originalMappings, util.compareByOriginalPositions);
+    for (var i = 0; i < originalMappings.length; i++) {
+      if (originalMappings[i] != null) {
+        quickSort(originalMappings[i], util.compareByOriginalPositionsNoSource);
+      }
+    }
+    this.__originalMappings = [].concat(...originalMappings);
   };
 
 /**

--- a/lib/source-map-consumer.js
+++ b/lib/source-map-consumer.js
@@ -464,6 +464,36 @@ function Mapping() {
  * query (the ordered arrays in the `this.__generatedMappings` and
  * `this.__originalMappings` properties).
  */
+
+const compareGenerated = util.compareByGeneratedPositionsDeflatedNoLine;
+function sortGenerated(array, start) {
+  let l = array.length;
+  let n = array.length - start;
+  if (n <= 1) {
+    return;
+  } else if (n == 2) {
+    let a = array[start];
+    let b = array[start + 1];
+    if (compareGenerated(a, b) > 0) {
+      array[start] = b;
+      array[start + 1] = a;
+    }
+  } else if (n < 20) {
+    for (let i = start; i < l; i++) {
+      for (let j = i; j > start; j--) {
+        let a = array[j - 1];
+        let b = array[j];
+        if (compareGenerated(a, b) <= 0) {
+          break;
+        }
+        array[j - 1] = b;
+        array[j] = a;
+      }
+    }
+  } else {
+    quickSort(array, compareGenerated, start);
+  }
+}
 BasicSourceMapConsumer.prototype._parseMappings =
   function SourceMapConsumer_parseMappings(aStr, aSourceRoot) {
     var generatedLine = 1;
@@ -480,11 +510,15 @@ BasicSourceMapConsumer.prototype._parseMappings =
     var generatedMappings = [];
     var mapping, str, segment, end, value;
 
+    let subarrayStart = 0;
     while (index < length) {
       if (aStr.charAt(index) === ';') {
         generatedLine++;
         index++;
         previousGeneratedColumn = 0;
+
+        sortGenerated(generatedMappings, subarrayStart);
+        subarrayStart = generatedMappings.length;
       }
       else if (aStr.charAt(index) === ',') {
         index++;
@@ -558,7 +592,7 @@ BasicSourceMapConsumer.prototype._parseMappings =
       }
     }
 
-    quickSort(generatedMappings, util.compareByGeneratedPositionsDeflated);
+    sortGenerated(generatedMappings, subarrayStart);
     this.__generatedMappings = generatedMappings;
 
     // The code used to sort the whole array:

--- a/lib/util.js
+++ b/lib/util.js
@@ -385,6 +385,38 @@ function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
 }
 exports.compareByOriginalPositions = compareByOriginalPositions;
 
+function compareByOriginalPositionsNoSource(mappingA, mappingB, onlyCompareOriginal) {
+  // var cmp = strcmp(mappingA.source, mappingB.source);
+  // if (cmp !== 0) {
+  //   return cmp;
+  // }
+
+  var cmp
+
+  cmp = mappingA.originalLine - mappingB.originalLine;
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  cmp = mappingA.originalColumn - mappingB.originalColumn;
+  if (cmp !== 0 || onlyCompareOriginal) {
+    return cmp;
+  }
+
+  cmp = mappingA.generatedColumn - mappingB.generatedColumn;
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  cmp = mappingA.generatedLine - mappingB.generatedLine;
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  return strcmp(mappingA.name, mappingB.name);
+}
+exports.compareByOriginalPositionsNoSource = compareByOriginalPositionsNoSource;
+
 /**
  * Comparator between two mappings with deflated source and name indices where
  * the generated positions are compared.

--- a/lib/util.js
+++ b/lib/util.js
@@ -386,11 +386,6 @@ function compareByOriginalPositions(mappingA, mappingB, onlyCompareOriginal) {
 exports.compareByOriginalPositions = compareByOriginalPositions;
 
 function compareByOriginalPositionsNoSource(mappingA, mappingB, onlyCompareOriginal) {
-  // var cmp = strcmp(mappingA.source, mappingB.source);
-  // if (cmp !== 0) {
-  //   return cmp;
-  // }
-
   var cmp
 
   cmp = mappingA.originalLine - mappingB.originalLine;

--- a/lib/util.js
+++ b/lib/util.js
@@ -456,6 +456,31 @@ function compareByGeneratedPositionsDeflated(mappingA, mappingB, onlyCompareGene
 }
 exports.compareByGeneratedPositionsDeflated = compareByGeneratedPositionsDeflated;
 
+function compareByGeneratedPositionsDeflatedNoLine(mappingA, mappingB, onlyCompareGenerated) {
+  var cmp = mappingA.generatedColumn - mappingB.generatedColumn;
+  if (cmp !== 0 || onlyCompareGenerated) {
+    return cmp;
+  }
+
+  cmp = strcmp(mappingA.source, mappingB.source);
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  cmp = mappingA.originalLine - mappingB.originalLine;
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  cmp = mappingA.originalColumn - mappingB.originalColumn;
+  if (cmp !== 0) {
+    return cmp;
+  }
+
+  return strcmp(mappingA.name, mappingB.name);
+}
+exports.compareByGeneratedPositionsDeflatedNoLine = compareByGeneratedPositionsDeflatedNoLine;
+
 function strcmp(aStr1, aStr2) {
   if (aStr1 === aStr2) {
     return 0;


### PR DESCRIPTION
I spotted the article [Maybe you don't need Rust and WASM to speed up your JS](https://mrale.ph/blog/2018/02/03/maybe-you-dont-need-rust-to-speed-up-your-js.html) written by @mraleph and decided to try to port non-hardcore optimizations.


I benchmarked it with `node 14.15.4`.

Before:

```
Parsing source map
iteration: 3.590s
iteration: 3.306s
iteration: 3.459s
iteration: 3.546s
iteration: 3.379s
iteration: 3.562s
iteration: 3.319s
[Stats samples: 7, total: 24158 ms, mean: 3451.1428571428573 ms, stddev: 128.1444497432487 ms]
```

After:

```
Parsing source map
iteration: 1.030s
iteration: 1.769s
iteration: 1.104s
iteration: 1.118s
iteration: 1.189s
iteration: 1.027s
iteration: 1.104s
iteration: 1.254s
iteration: 1.041s
iteration: 1.060s
iteration: 1.140s
iteration: 1.103s
iteration: 1.124s
iteration: 1.092s
iteration: 1.098s
iteration: 1.083s
iteration: 1.068s
iteration: 1.129s
iteration: 1.067s
iteration: 1.129s
iteration: 1.090s
iteration: 1.094s
[Stats samples: 22, total: 24913 ms, mean: 1132.409090909091 ms, stddev: 154.70478799497909 ms]
```